### PR TITLE
Add progress modal to start process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@inubekit/countdownbar": "^2.5.0",
         "@inubekit/divider": "^0.2.0",
         "@inubekit/fieldset": "^0.6.0",
+        "@inubekit/flag": "^7.1.0",
         "@inubekit/foundations": "^5.11.2",
         "@inubekit/grid": "^2.1.0",
         "@inubekit/header": "^2.1.2",
@@ -3064,12 +3065,12 @@
       }
     },
     "node_modules/@inubekit/button": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@inubekit/button/-/button-4.33.0.tgz",
-      "integrity": "sha512-WWngtWkOARdLDIVUqQKcuIvEmpe1ylkc/Vup2gRkLYz5pb0n3p3oB8EKJCSLbX74vBEFU2Rn0Hylnvnt/4xP4w==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@inubekit/button/-/button-4.34.0.tgz",
+      "integrity": "sha512-06MKFT66t8iCpSG36XkWQf8VLi7NlYZXDBHuXhWMSp4141WF+OZS2hT2A6z08c9vSlD5EMZ50mnnR63av5xASg==",
       "dependencies": {
         "@inubekit/foundations": "^5.11.2",
-        "@inubekit/icon": "^2.15.0",
+        "@inubekit/icon": "^2.15.1",
         "@inubekit/spinner": "^2.3.0",
         "@inubekit/stack": "^3.8.0",
         "@inubekit/text": "^2.15.0"
@@ -3137,6 +3138,39 @@
       "dependencies": {
         "@inubekit/foundations": "^5.0.0",
         "@inubekit/stack": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "styled-components": "^6.1.8"
+      }
+    },
+    "node_modules/@inubekit/flag": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@inubekit/flag/-/flag-7.1.0.tgz",
+      "integrity": "sha512-g5v7ct67aYlBkzgmV51jYLX6/+s1Gre5gEYyQLlFDVJ1uGkSriTbl8d/8Je57kQ23l0+zVWmJrnsy+lzqaE6VA==",
+      "dependencies": {
+        "@inubekit/button": "^4.34.0",
+        "@inubekit/countdownbar": "^2.5.0",
+        "@inubekit/foundations": "^5.11.2",
+        "@inubekit/hooks": "^1.2.0",
+        "@inubekit/icon": "^2.15.0",
+        "@inubekit/stack": "^3.8.0",
+        "@inubekit/text": "^2.15.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
+        "styled-components": "^6.1.8"
+      }
+    },
+    "node_modules/@inubekit/flag/node_modules/@inubekit/stack": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@inubekit/stack/-/stack-3.8.0.tgz",
+      "integrity": "sha512-OyVgOcZkE59+sepHjxwcEpYYCVf4wbRToxaspdFha0jW7fUUj+tlm9bBygtZVD5V67PZPu6h5eEWdO7Who5u5g==",
+      "dependencies": {
+        "@inubekit/foundations": "^5.11.2"
       },
       "peerDependencies": {
         "react": "^18.2.0",
@@ -3245,9 +3279,9 @@
       }
     },
     "node_modules/@inubekit/icon": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@inubekit/icon/-/icon-2.15.0.tgz",
-      "integrity": "sha512-zy942REsMx6defOVLj4jJeRpEBrf2Y7TPsqsSevYiuw3AbPBsW4zdGknAPJmOjTd/6hKRB3yceX6weudw7vsgw==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@inubekit/icon/-/icon-2.15.1.tgz",
+      "integrity": "sha512-FFAJonKMoDitnuhAfqvskTkS8PmpuvGSZv9WYadAJSLS1UEoIrf/CIGoHjZ6JglegHebFqKEfj9JRRKPTeH3vQ==",
       "dependencies": {
         "@inubekit/foundations": "^5.11.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@inubekit/countdownbar": "^2.5.0",
         "@inubekit/divider": "^0.2.0",
         "@inubekit/fieldset": "^0.6.0",
-        "@inubekit/foundations": "^5.1.0",
+        "@inubekit/foundations": "^5.11.2",
         "@inubekit/grid": "^2.1.0",
         "@inubekit/header": "^2.1.2",
         "@inubekit/hooks": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@inubekit/countdownbar": "^2.5.0",
     "@inubekit/divider": "^0.2.0",
     "@inubekit/fieldset": "^0.6.0",
+    "@inubekit/flag": "^7.1.0",
     "@inubekit/foundations": "^5.11.2",
     "@inubekit/grid": "^2.1.0",
     "@inubekit/header": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@inubekit/countdownbar": "^2.5.0",
     "@inubekit/divider": "^0.2.0",
     "@inubekit/fieldset": "^0.6.0",
-    "@inubekit/foundations": "^5.1.0",
+    "@inubekit/foundations": "^5.11.2",
     "@inubekit/grid": "^2.1.0",
     "@inubekit/header": "^2.1.2",
     "@inubekit/hooks": "^1.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { FinishedRoutes } from "./routes/finished";
 import { StartProcessRoutes } from "./routes/startProcess";
 import { ValidateProgressRoutes } from "./routes/validateProgress";
 import { theme } from "./config/theme";
+import { FlagProvider } from "@inubekit/flag";
 
 
 function LogOut() {
@@ -69,9 +70,11 @@ function App() {
     <>
     <GlobalStyles />
     <ThemeProvider theme={theme}> 
+    <FlagProvider>
     <AppContextProvider>
       <RouterProvider router={router} />
     </AppContextProvider>
+    </FlagProvider>
     </ThemeProvider>
     </>
   );

--- a/src/components/feedback/ProgressCardWithBarDetermined/index.tsx
+++ b/src/components/feedback/ProgressCardWithBarDetermined/index.tsx
@@ -19,6 +19,7 @@ interface ProgressCardWithBarDeterminedProps {
   progress: number;
   portalId: string;
   isAnimated: boolean;
+  isProcessCompleted?: boolean;
   withButtonClose?: boolean;
   heightProgressBar?: string;
   appearance?: ProgressCardWithBarType;
@@ -30,6 +31,7 @@ const ProgressCardWithBarDetermined = (
 ) => {
   const {
     withButtonClose = false,
+    isProcessCompleted = false,
     estime,
     progress,
     portalId,
@@ -59,7 +61,6 @@ const ProgressCardWithBarDetermined = (
                 Este proceso tomará algo de tiempo, por favor espere hasta que
                 se complete.
               </Text>
-
               <Stack direction="column" alignItems="center">
                 <Text type="body" size="medium" appearance="dark">
                   Tiempo Estimado: {estime} Segundos
@@ -93,7 +94,7 @@ const ProgressCardWithBarDetermined = (
                   appearance="primary"
                   variant="filled"
                   onClick={onCancel}
-                  disabled={progress !== 100}
+                  disabled={isProcessCompleted}
                 >
                   Cerrar
                 </Button>

--- a/src/components/feedback/ProgressCardWithBarDetermined/index.tsx
+++ b/src/components/feedback/ProgressCardWithBarDetermined/index.tsx
@@ -18,6 +18,7 @@ interface ProgressCardWithBarDeterminedProps {
   estime: number;
   progress: number;
   portalId: string;
+  isAnimated: boolean;
   withButtonClose?: boolean;
   heightProgressBar?: string;
   appearance?: ProgressCardWithBarType;
@@ -34,6 +35,7 @@ const ProgressCardWithBarDetermined = (
     portalId,
     heightProgressBar = tokens.spacing.s200,
     appearance,
+    isAnimated,
     onCancel,
   } = props;
 
@@ -77,7 +79,7 @@ const ProgressCardWithBarDetermined = (
                   <ProgressBar
                     progress={progress}
                     height={heightProgressBar}
-                    animated
+                    animated={isAnimated}
                     appearance={appearance}
                   />
                 </StyledContainerProgressBar>

--- a/src/components/feedback/ProgressCardWithBarDetermined/stories/ProgressCardWithBarDetermined.stories.tsx
+++ b/src/components/feedback/ProgressCardWithBarDetermined/stories/ProgressCardWithBarDetermined.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta<typeof ProgressCardWithBarDetermined> = {
   ],
 };
 
-const DynamicProgressCardWithBarDetermined = ({ children }: { children: React.ReactElement<{ progress: number }> }) => {
+const DynamicProgressCardWithBarDetermined = ({ children }: { children: React.ReactElement<{ progress: number, isProcessCompleted: boolean, isAnimated: boolean }> }) => {
   const [percentage, setPercentage] = useState(0);
 
   useEffect(() => {
@@ -70,6 +70,8 @@ const DynamicProgressCardWithBarDetermined = ({ children }: { children: React.Re
     <>
       {React.isValidElement(children) && React.cloneElement(children, {
         progress: percentage,
+        isProcessCompleted: percentage !== 100,
+        isAnimated: percentage !== 100,
       })}
     </>
   );
@@ -101,6 +103,7 @@ Default.args = {
   portalId: "portal",
   heightProgressBar: tokens.spacing.s200,
   appearance: "primary",
+  
 };
 
 Default.argTypes ={

--- a/src/components/feedback/ProgressCardWithBarIndetermined/index.tsx
+++ b/src/components/feedback/ProgressCardWithBarIndetermined/index.tsx
@@ -11,21 +11,22 @@ import { StyledContainer, StyledModal } from "./styles";
 import { ProgressCardWithBarType } from "../ProgressCardWithBarDetermined/types";
 import { tokens } from "@design/tokens";
 
-
 interface ProgressCardWithBarIndeterminedProps {
   portalId: string;
-  appearance?:ProgressCardWithBarType;
+  appearance?: ProgressCardWithBarType;
   withButtonClose?: boolean;
-  withDisabledButton?: boolean;
+  isProcessCompleted?: boolean;
   onCancel?: () => void;
 }
 
-const ProgressCardWithBarIndetermined = (props: ProgressCardWithBarIndeterminedProps) => {
+const ProgressCardWithBarIndetermined = (
+  props: ProgressCardWithBarIndeterminedProps
+) => {
   const {
     portalId,
     appearance = "primary",
     withButtonClose,
-    withDisabledButton,
+    isProcessCompleted,
     onCancel,
   } = props;
 
@@ -65,7 +66,7 @@ const ProgressCardWithBarIndetermined = (props: ProgressCardWithBarIndeterminedP
                   appearance="primary"
                   variant="filled"
                   onClick={onCancel}
-                  disabled={withDisabledButton}
+                  disabled={!isProcessCompleted}
                 >
                   Cerrar
                 </Button>

--- a/src/components/feedback/ProgressCardWithBarIndetermined/stories/ProgressCardWithBarIndetermined.stories.tsx
+++ b/src/components/feedback/ProgressCardWithBarIndetermined/stories/ProgressCardWithBarIndetermined.stories.tsx
@@ -82,6 +82,7 @@ export const WithButtonClose: StoryFn<ProgressCardWithBarIndeterminedProps> =
 WithButtonClose.args = {
   withButtonClose: true,
   portalId: "portal",
+  isProcessCompleted: true,
 };
 
 const TemplateThemed: StoryFn<ProgressCardWithBarIndeterminedProps> = (

--- a/src/components/layout/ErrorPage/index.tsx
+++ b/src/components/layout/ErrorPage/index.tsx
@@ -18,6 +18,8 @@ interface ErrorPageProps {
   description?: string;
   image?: string;
   imageAlt?: string;
+  nameButton?: string;
+  onClick?: () => void;
 }
 
 function ErrorPage(props: ErrorPageProps) {
@@ -28,6 +30,8 @@ function ErrorPage(props: ErrorPageProps) {
     description = "El servicio no se encuentra disponible en el momento. Por favor intenta de nuevo más tarde.",
     image = errorImage,
     imageAlt = "Ha surgido un error. Revisa la descripción",
+    nameButton = "volver",
+    onClick,
   } = props;
 
   const mediaQueries = ["(max-width: 1000px)", "(max-width: 600px)"];
@@ -55,7 +59,7 @@ function ErrorPage(props: ErrorPageProps) {
               {description}
             </Text>
           </Stack>
-          <Button iconBefore={<MdChevronLeft size={18} />}>Exit</Button>
+          <Button iconBefore={<MdChevronLeft size={18} />} onClick={onClick}>{nameButton}</Button>
         </Stack>
         <StyledErrorImage src={image} alt={imageAlt} />
       </Grid>

--- a/src/components/modals/StartProcessModal/stories/StartProcessModal.stories.tsx
+++ b/src/components/modals/StartProcessModal/stories/StartProcessModal.stories.tsx
@@ -32,7 +32,7 @@ const data = {
   descriptionSuggested:
     "Los NFTs son tokens no fungibles únicos en la cadena de bloques. A diferencia de las criptomonedas",
   date: "10/Jul/2024 - 14:05:00",
-  plannedAutomaticExecution: "planned automatic execution"
+  executionWay: "PlannedAutomaticExecution"
 };
 
 const Template: StoryFn<StartProcessModalProps> = (args) => {
@@ -70,8 +70,8 @@ const TemplateWithPlannedAutomatic: StoryFn<StartProcessModalProps> = (args) => 
   );
 };
 
-export const WithPlannedAutomaticExecution: StoryFn<StartProcessModalProps>  = TemplateWithPlannedAutomatic.bind({});
-WithPlannedAutomaticExecution.args = {
+export const WithexecutionWay: StoryFn<StartProcessModalProps>  = TemplateWithPlannedAutomatic.bind({});
+WithexecutionWay.args = {
   portalId: "portal",
   children: (  <RefreshSavingProduct data={data}
     onStartProcess={() => true}

--- a/src/forms/card/RefreshCardCreditProduct/index.tsx
+++ b/src/forms/card/RefreshCardCreditProduct/index.tsx
@@ -70,8 +70,8 @@ const RefreshCardCreditProduct = (props: RefreshCardCreditProductProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -81,7 +81,7 @@ const RefreshCardCreditProduct = (props: RefreshCardCreditProductProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -97,13 +97,11 @@ const RefreshCardCreditProduct = (props: RefreshCardCreditProductProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/card/RefreshCardCreditProduct/interface.tsx
+++ b/src/forms/card/RefreshCardCreditProduct/interface.tsx
@@ -106,9 +106,9 @@ const RefreshCardCreditProductUI = (props: RefreshCardCreditProductUIProps) => {
             </Fieldset>
           </StyledField>
 
-          {data?.plannedAutomaticExecution &&
-            data?.plannedAutomaticExecution ===
-              "planned automatic execution" && (
+          {data?.executionWay &&
+            data?.executionWay ===
+              "PlannedAutomaticExecution" && (
               <Datetimefield
                 withFullwidth={true}
                 id="plannedExecutionDate"

--- a/src/forms/card/RefreshSavingProductCard/index.tsx
+++ b/src/forms/card/RefreshSavingProductCard/index.tsx
@@ -63,8 +63,8 @@ const RefreshSavingProductCard = (props: RefreshSavingProductCardProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -74,7 +74,7 @@ const RefreshSavingProductCard = (props: RefreshSavingProductCardProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -90,13 +90,11 @@ const RefreshSavingProductCard = (props: RefreshSavingProductCardProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/card/RefreshSavingProductCard/interface.tsx
+++ b/src/forms/card/RefreshSavingProductCard/interface.tsx
@@ -99,8 +99,8 @@ const RefreshSavingProductCardUI = (props: RefreshSavingProductCardUIProps) => {
           </Fieldset>
         </StyledField>
 
-        {data?.plannedAutomaticExecution &&
-          data?.plannedAutomaticExecution === "planned automatic execution" && (
+        {data?.executionWay &&
+          data?.executionWay === "PlannedAutomaticExecution" && (
             <Datetimefield
               withFullwidth={true}
               id="plannedExecutionDate"

--- a/src/forms/credit/RefreshCreditRequest/index.tsx
+++ b/src/forms/credit/RefreshCreditRequest/index.tsx
@@ -63,8 +63,8 @@ const handleChange = (name: string, value: string) => {
 
 useEffect(() => {
   if (
-    data?.plannedAutomaticExecution &&
-    data?.plannedAutomaticExecution === "planned automatic execution"
+    data?.executionWay &&
+    data?.executionWay === "PlannedAutomaticExecution"
   ) {
     setDynamicValidationSchema(
       validationSchema.shape({
@@ -74,7 +74,7 @@ useEffect(() => {
       })
     );
   }
-}, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+}, [data?.executionWay, setDynamicValidationSchema]);
 
 useEffect(() => {
   if (formik.values) {
@@ -90,13 +90,11 @@ useEffect(() => {
 }, [formik.values, setFieldsEntered]);
 
 const comparisonData = Boolean(
-  (data?.plannedAutomaticExecution &&
-    formik.values.plannedExecutionDate.length > 0 &&
+  (data?.executionWay === "PlannedAutomaticExecution" &&
     formik.values.typeRefresh !== initialValues.typeRefresh &&
     formik.values.plannedExecutionDate !==
       initialValues.plannedExecutionDate) ||
-    (!data?.plannedAutomaticExecution &&
-      formik.values.typeRefresh !== initialValues.typeRefresh)
+    formik.values.typeRefresh !== initialValues.typeRefresh
 );
 
 return (

--- a/src/forms/credit/RefreshCreditRequest/interface.tsx
+++ b/src/forms/credit/RefreshCreditRequest/interface.tsx
@@ -106,8 +106,8 @@ const RefreshCreditRequestUI = (props: RefreshCreditRequestUIProps) => {
           </Fieldset>
         </StyledField>
 
-        {data?.plannedAutomaticExecution &&
-          data?.plannedAutomaticExecution === "planned automatic execution" && (
+        {data?.executionWay &&
+          data?.executionWay === "PlannedAutomaticExecution" && (
             <Datetimefield
               withFullwidth={true}
               id="plannedExecutionDate"

--- a/src/forms/customers/RefreshCustomerAttributes/index.tsx
+++ b/src/forms/customers/RefreshCustomerAttributes/index.tsx
@@ -3,7 +3,12 @@ import * as Yup from "yup";
 import { useEffect, useState } from "react";
 
 import { EnumProcessCoverageData } from "@services/enumerators/getEnumeratorsProcessCoverage";
-import { IStartProcessEntry, IEntries, IFieldsEntered, IEnumeratorsProcessCoverage } from "@forms/types";
+import {
+  IStartProcessEntry,
+  IEntries,
+  IFieldsEntered,
+  IEnumeratorsProcessCoverage,
+} from "@forms/types";
 import { RefreshCustomerAttributesUI } from "./interface";
 
 const validationSchema = Yup.object({
@@ -30,21 +35,23 @@ const RefreshCustomerAttributes = (props: RefreshCustomerAttributesProps) => {
   const [dynamicValidationSchema, setDynamicValidationSchema] =
     useState(validationSchema);
 
-    const [optionsTypeRefresh, setOptionsTypeRefresh] = useState<IEnumeratorsProcessCoverage[]>([]);
+  const [optionsTypeRefresh, setOptionsTypeRefresh] = useState<
+    IEnumeratorsProcessCoverage[]
+  >([]);
 
-    const validateOptionsTypeRefresh = async () => {
-      try {
-        const newOptions = await EnumProcessCoverageData();
-  
-        setOptionsTypeRefresh(newOptions);
-      } catch (error) {
-        console.info(error);
-      } 
-    };
+  const validateOptionsTypeRefresh = async () => {
+    try {
+      const newOptions = await EnumProcessCoverageData();
 
-    useEffect(() => {
-      validateOptionsTypeRefresh();
-    }, []);
+      setOptionsTypeRefresh(newOptions);
+    } catch (error) {
+      console.info(error);
+    }
+  };
+
+  useEffect(() => {
+    validateOptionsTypeRefresh();
+  }, []);
 
   const formik = useFormik({
     initialValues,
@@ -54,7 +61,7 @@ const RefreshCustomerAttributes = (props: RefreshCustomerAttributesProps) => {
   });
 
   const handleChange = (name: string, value: string) => {
-    formik.setFieldValue(name, value).then(()=> {
+    formik.setFieldValue(name, value).then(() => {
       formik.validateForm().then((errors) => {
         formik.setErrors(errors);
       });
@@ -63,8 +70,8 @@ const RefreshCustomerAttributes = (props: RefreshCustomerAttributesProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -74,7 +81,7 @@ const RefreshCustomerAttributes = (props: RefreshCustomerAttributesProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -90,13 +97,11 @@ const RefreshCustomerAttributes = (props: RefreshCustomerAttributesProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/customers/RefreshCustomerAttributes/interface.tsx
+++ b/src/forms/customers/RefreshCustomerAttributes/interface.tsx
@@ -108,9 +108,9 @@ const RefreshCustomerAttributesUI = (
             </Fieldset>
           </StyledField>
 
-          {data?.plannedAutomaticExecution &&
-            data?.plannedAutomaticExecution ===
-              "planned automatic execution" && (
+          {data?.executionWay &&
+            data?.executionWay ===
+              "PlannedAutomaticExecution" && (
               <Datetimefield
                 withFullwidth={true}
                 id="plannedExecutionDate"

--- a/src/forms/otherDebt/RefreshOtherDebt/index.tsx
+++ b/src/forms/otherDebt/RefreshOtherDebt/index.tsx
@@ -70,8 +70,8 @@ const RefreshOtherDebt = (props: RefreshOtherDebtProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -81,7 +81,7 @@ const RefreshOtherDebt = (props: RefreshOtherDebtProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -97,13 +97,11 @@ const RefreshOtherDebt = (props: RefreshOtherDebtProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/otherDebt/RefreshOtherDebt/interface.tsx
+++ b/src/forms/otherDebt/RefreshOtherDebt/interface.tsx
@@ -106,9 +106,9 @@ const RefreshOtherDebtUI = (props: RefreshOtherDebtUIProps) => {
             </Fieldset>
           </StyledField>
 
-          {data?.plannedAutomaticExecution &&
-            data?.plannedAutomaticExecution ===
-              "planned automatic execution" && (
+          {data?.executionWay &&
+            data?.executionWay ===
+              "PlannedAutomaticExecution" && (
               <Datetimefield
                 withFullwidth={true}
                 id="plannedExecutionDate"

--- a/src/forms/portfolio/RefreshInterestStatusUpdate/index.tsx
+++ b/src/forms/portfolio/RefreshInterestStatusUpdate/index.tsx
@@ -37,8 +37,8 @@ const formik = useFormik({
 
 useEffect(() => {
   if (
-    data?.plannedAutomaticExecution &&
-    data?.plannedAutomaticExecution === "planned automatic execution"
+    data?.executionWay &&
+    data?.executionWay === "PlannedAutomaticExecution"
   ) {
     setDynamicValidationSchema(
       validationSchema.shape({
@@ -48,7 +48,7 @@ useEffect(() => {
       })
     );
   }
-}, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+}, [data?.executionWay, setDynamicValidationSchema]);
 
 useEffect(() => {
   if (formik.values) {

--- a/src/forms/portfolio/RefreshInterestStatusUpdate/interface.tsx
+++ b/src/forms/portfolio/RefreshInterestStatusUpdate/interface.tsx
@@ -74,8 +74,8 @@ const RefreshInterestStatusUpdateUI = (props: RefreshInterestStatusUpdateUIProps
           </Fieldset>
         </StyledField>
 
-        {data?.plannedAutomaticExecution &&
-          data?.plannedAutomaticExecution === "planned automatic execution" && (
+        {data?.executionWay &&
+          data?.executionWay === "PlannedAutomaticExecution" && (
             <Datetimefield
               withFullwidth={true}
               id="plannedExecutionDate"
@@ -102,8 +102,8 @@ const RefreshInterestStatusUpdateUI = (props: RefreshInterestStatusUpdateUIProps
             variant="filled"
             type="submit"
             onClick={onStartProcess}
-            disabled={data?.plannedAutomaticExecution &&
-              data?.plannedAutomaticExecution === "planned automatic execution" ? !comparisonData : false }
+            disabled={data?.executionWay &&
+              data?.executionWay === "PlannedAutomaticExecution" ? !comparisonData : false }
           >
             Iniciar proceso
           </Button>

--- a/src/forms/portfolio/RefreshPortfolioObligation/index.tsx
+++ b/src/forms/portfolio/RefreshPortfolioObligation/index.tsx
@@ -70,8 +70,8 @@ const RefreshPortfolioObligation = (props: RefreshPortfolioObligationProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -81,7 +81,7 @@ const RefreshPortfolioObligation = (props: RefreshPortfolioObligationProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -97,13 +97,11 @@ const RefreshPortfolioObligation = (props: RefreshPortfolioObligationProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/portfolio/RefreshPortfolioObligation/interface.tsx
+++ b/src/forms/portfolio/RefreshPortfolioObligation/interface.tsx
@@ -108,9 +108,9 @@ const RefreshPortfolioObligationUI = (
             </Fieldset>
           </StyledField>
 
-          {data?.plannedAutomaticExecution &&
-            data?.plannedAutomaticExecution ===
-              "planned automatic execution" && (
+          {data?.executionWay &&
+            data?.executionWay ===
+              "PlannedAutomaticExecution" && (
               <Datetimefield
                 withFullwidth={true}
                 id="plannedExecutionDate"

--- a/src/forms/savings/RefreshSavingCommitment/index.tsx
+++ b/src/forms/savings/RefreshSavingCommitment/index.tsx
@@ -70,8 +70,8 @@ const RefreshSavingCommitment = (props: RefreshSavingCommitmentProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -81,7 +81,7 @@ const RefreshSavingCommitment = (props: RefreshSavingCommitmentProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -97,13 +97,11 @@ const RefreshSavingCommitment = (props: RefreshSavingCommitmentProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/savings/RefreshSavingCommitment/interface.tsx
+++ b/src/forms/savings/RefreshSavingCommitment/interface.tsx
@@ -106,9 +106,9 @@ const RefreshSavingCommitmentUI = (props: RefreshSavingCommitmentUIProps) => {
             </Fieldset>
           </StyledField>
 
-          {data?.plannedAutomaticExecution &&
-            data?.plannedAutomaticExecution ===
-              "planned automatic execution" && (
+          {data?.executionWay &&
+            data?.executionWay ===
+              "PlannedAutomaticExecution" && (
               <Datetimefield
                 withFullwidth={true}
                 id="plannedExecutionDate"

--- a/src/forms/savings/RefreshSavingProduct/index.tsx
+++ b/src/forms/savings/RefreshSavingProduct/index.tsx
@@ -70,8 +70,8 @@ const RefreshSavingProduct = (props: RefreshSavingProductProps) => {
 
   useEffect(() => {
     if (
-      data?.plannedAutomaticExecution &&
-      data?.plannedAutomaticExecution === "planned automatic execution"
+      data?.executionWay &&
+      data?.executionWay === "PlannedAutomaticExecution"
     ) {
       setDynamicValidationSchema(
         validationSchema.shape({
@@ -81,7 +81,7 @@ const RefreshSavingProduct = (props: RefreshSavingProductProps) => {
         })
       );
     }
-  }, [data?.plannedAutomaticExecution, setDynamicValidationSchema]);
+  }, [data?.executionWay, setDynamicValidationSchema]);
 
   useEffect(() => {
     if (formik.values) {
@@ -97,13 +97,11 @@ const RefreshSavingProduct = (props: RefreshSavingProductProps) => {
   }, [formik.values, setFieldsEntered]);
 
   const comparisonData = Boolean(
-    (data?.plannedAutomaticExecution &&
-      formik.values.plannedExecutionDate.length > 0 &&
+    (data?.executionWay === "PlannedAutomaticExecution" &&
       formik.values.typeRefresh !== initialValues.typeRefresh &&
       formik.values.plannedExecutionDate !==
         initialValues.plannedExecutionDate) ||
-      (!data?.plannedAutomaticExecution &&
-        formik.values.typeRefresh !== initialValues.typeRefresh)
+      formik.values.typeRefresh !== initialValues.typeRefresh
   );
 
   return (

--- a/src/forms/savings/RefreshSavingProduct/interface.tsx
+++ b/src/forms/savings/RefreshSavingProduct/interface.tsx
@@ -98,8 +98,8 @@ const RefreshSavingProductUI = (props: RefreshSavingProductUIProps) => {
           </Fieldset>
         </StyledField>
 
-        {data?.plannedAutomaticExecution &&
-          data?.plannedAutomaticExecution === "planned automatic execution" && (
+        {data?.executionWay &&
+          data?.executionWay === "PlannedAutomaticExecution" && (
             <Datetimefield
               withFullwidth={true}
               id="plannedExecutionDate"

--- a/src/pages/startProcess/tabs/onDemand/components/OnDemandRequirements/interface.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/OnDemandRequirements/interface.tsx
@@ -46,12 +46,16 @@ const OnDemandRequirementsUI = (props: OnDemandRequirementsUIProps) => {
     handleToggleModal,
   } = props;
 
+  const validateStatus =
+    normalizeStatusRequirement?.name === "Sin Evaluar" ||
+    normalizeStatusRequirement?.name === "No Cumple";
+
   return (
     <>
       {isVisibleStatusReq ? (
         <SkeletonLine width="80px" animated />
       ) : (
-        <StyledContainer onClick={handleToggleModal}>
+        <StyledContainer onClick={handleToggleModal} $withCursor={validateStatus}>
           {statusRequirement && statusRequirement?.generalStatus?.length > 0 ? (
             <Stack gap={tokens.spacing.s050} direction="row">
               <Stack height="80%">
@@ -64,8 +68,7 @@ const OnDemandRequirementsUI = (props: OnDemandRequirementsUIProps) => {
                   weight="strong"
                 />
               </Stack>
-              {(normalizeStatusRequirement?.name === "Sin Evaluar" ||
-                normalizeStatusRequirement?.name === "No Cumple") && (
+              {validateStatus && (
                 <Tooltip
                   description={
                     "Puede hacer clic en el botón para prevalidar los requisitos"
@@ -84,8 +87,7 @@ const OnDemandRequirementsUI = (props: OnDemandRequirementsUIProps) => {
         </StyledContainer>
       )}
 
-      {(normalizeStatusRequirement?.name === "Sin Evaluar" ||
-        normalizeStatusRequirement?.name === "No Cumple") &&
+      {validateStatus &&
         showModal &&
         id && (
           <RequirementsModal

--- a/src/pages/startProcess/tabs/onDemand/components/OnDemandRequirements/styles.ts
+++ b/src/pages/startProcess/tabs/onDemand/components/OnDemandRequirements/styles.ts
@@ -1,7 +1,12 @@
 import styled from "styled-components";
 
-const StyledContainer = styled.div`
-cursor: pointer;
+interface IStyledContainer {
+    $withCursor: boolean;
+}
+
+const StyledContainer = styled.div<IStyledContainer>`
+cursor:${({  $withCursor }) =>
+   $withCursor && "pointer" }; 
 `;
 
 export { StyledContainer };

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -34,7 +34,7 @@ const percentageElapsed = (
   const currentMoment = calculateSeconds(dateCurrent);
   const percentageResp = calculatePercentage(currentMoment, time, dateStart);
 
-  if (percentageResp >= 100 || isNaN(percentageResp)) {
+  if (percentageResp >= 100) {
     return 100;
   }
   return percentageResp;
@@ -45,13 +45,13 @@ const ProgressOfStartProcessOnDemand = (
 ) => {
   const { id,  dateStart } = props;
   const [percentage, setPercentage] = useState(0);
-  const [processTime, setProcessTime] = useState<string>("");
+  const [processTime, setProcessTime] = useState<number | undefined>();
+  const [time, setTime] = useState<Date | undefined>();
 
   const validateTimeToCompleteProcess = async (progressControlId: string) => {
     try {
       const newTime = await timeToCompleteProcess(progressControlId);
-      setProcessTime(newTime.duration);
-      processTime
+      setProcessTime(newTime.secondsTime);
     } catch (error) {
       console.info(error);
     }
@@ -69,13 +69,19 @@ const ProgressOfStartProcessOnDemand = (
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, []);
-
-  const time = stringToTime("00:00:50"); ///se coloca este tiempo para pruebas debido a que estan ajustando el endpoint que calcula el tiempo
-  const timeSeconds = calculateSeconds(time);
+  }, [id]);
 
   useEffect(() => {
-    const timer = setInterval(() => {
+    if (processTime) {
+      setTime(stringToTime(processTime));
+    }
+  }, [processTime]);
+
+  const timeSeconds = time ? calculateSeconds(time as Date) : 0;
+
+
+  useEffect(() => {
+     const timer = setInterval(() => {
       const newPercentage = percentageElapsed(
         timeSeconds,
         percentage,
@@ -90,13 +96,12 @@ const ProgressOfStartProcessOnDemand = (
       }
     }, 300);
     return () => clearInterval(timer);
-  }, [percentage]);
-
+  }, [percentage, timeSeconds, dateStart]);
 
 
   return (
     <>
-    {!timeSeconds || timeSeconds === 0 ? (
+    {!time ? (
       <ProgressCardWithBarIndetermined
         portalId="portal"
       />

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+
+import { ProgressCardWithBarDetermined } from "@components/feedback/ProgressCardWithBarDetermined";
+import { timeToCompleteProcess } from "@services/startProcess/getTimeToCompleteProcess";
+import { calculateSeconds, stringToTime } from "@pages/startProcess/utils";
+
+interface ProgressOfStartProcessOnDemandProps {
+  dateStart: Date;
+  id: string;
+  handleShowProgressModal: (showModal: boolean) => void;
+}
+
+const calculatePercentage = (
+  currentMoment: number,
+  time: number,
+  dateStart: Date
+) => {
+  const secondsElapsed = currentMoment - calculateSeconds(dateStart);
+  const secondsValid = secondsElapsed >= 0 ? secondsElapsed : 0;
+  return (secondsValid / time) * 100;
+};
+
+const percentageElapsed = (
+  time: number,
+  percentageDos: number,
+  dateStart: Date
+): number => {
+  if (percentageDos >= 100) {
+    return percentageDos;
+  }
+
+  const dateCurrent = new Date();
+  const currentMoment = calculateSeconds(dateCurrent);
+  const percentageResp = calculatePercentage(currentMoment, time, dateStart);
+
+  if (percentageResp >= 100 || isNaN(percentageResp)) {
+    return 100;
+  }
+  return percentageResp;
+};
+
+const ProgressOfStartProcessOnDemand = (
+  props: ProgressOfStartProcessOnDemandProps
+) => {
+  const { id, handleShowProgressModal, dateStart } = props;
+  const [percentage, setPercentage] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [processTime, setProcessTime] = useState<string>("");
+
+  const validateTimeToCompleteProcess = async (progressControlId: string) => {
+    try {
+      const newTime = await timeToCompleteProcess(progressControlId);
+      setProcessTime(newTime.duration);
+      setShowModal(true);
+    } catch (error) {
+      console.info(error);
+    }
+  };
+  useEffect(() => {
+    validateTimeToCompleteProcess(id);
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const message = "¿Estás seguro de que quieres salir?";
+      event.returnValue = message;
+      return message;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  const time = stringToTime(processTime);
+  const timeSeconds = calculateSeconds(time);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const newPercentage = percentageElapsed(
+        timeSeconds,
+        percentage,
+        dateStart
+      );
+
+      if (newPercentage >= 100) {
+        clearInterval(timer);
+        setPercentage(100);
+      } else {
+        setPercentage(newPercentage);
+      }
+    }, 300);
+    return () => clearInterval(timer);
+  }, [percentage]);
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+    handleShowProgressModal(false);
+  };
+
+  return (
+    <>
+      <ProgressCardWithBarDetermined
+        estime={timeSeconds}
+        progress={percentage}
+        portalId="portal"
+        withButtonClose
+        isAnimated={percentage === 100 ? false : true}
+        onCancel={handleToggleModal}
+      />
+    </>
+  );
+};
+
+export default ProgressOfStartProcessOnDemand;

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -3,11 +3,19 @@ import { useEffect, useState } from "react";
 import { ProgressCardWithBarDetermined } from "@components/feedback/ProgressCardWithBarDetermined";
 import { timeToCompleteProcess } from "@services/startProcess/getTimeToCompleteProcess";
 import { calculateSeconds, stringToTime } from "@pages/startProcess/utils";
+import { ProgressCardWithBarIndetermined } from "@components/feedback/ProgressCardWithBarIndetermined";
 
 interface ProgressOfStartProcessOnDemandProps {
   dateStart: Date;
   id: string;
-  handleShowProgressModal: (showModal: boolean) => void;
+  handleShowProgressModal?: (showModal: boolean) => void;
+}
+
+ //se crea funcion para que genere dos posibles tiempos aleatorios ya que se va ajustar 
+  //el endpoint que calcula el tiempo de inicio de un proceso
+  function getRandomTime(): string {
+    const randomValue = Math.floor(Math.random() * 2);
+    return randomValue === 0 ? "00:00:00" : "00:00:50";
 }
 
 const calculatePercentage = (
@@ -42,16 +50,15 @@ const percentageElapsed = (
 const ProgressOfStartProcessOnDemand = (
   props: ProgressOfStartProcessOnDemandProps
 ) => {
-  const { id, handleShowProgressModal, dateStart } = props;
+  const { id,  dateStart } = props;
   const [percentage, setPercentage] = useState(0);
-  const [showModal, setShowModal] = useState(false);
   const [processTime, setProcessTime] = useState<string>("");
 
   const validateTimeToCompleteProcess = async (progressControlId: string) => {
     try {
       const newTime = await timeToCompleteProcess(progressControlId);
       setProcessTime(newTime.duration);
-      setShowModal(true);
+      processTime
     } catch (error) {
       console.info(error);
     }
@@ -71,7 +78,7 @@ const ProgressOfStartProcessOnDemand = (
     };
   }, []);
 
-  const time = stringToTime(processTime);
+  const time = stringToTime(getRandomTime());
   const timeSeconds = calculateSeconds(time);
 
   useEffect(() => {
@@ -92,22 +99,23 @@ const ProgressOfStartProcessOnDemand = (
     return () => clearInterval(timer);
   }, [percentage]);
 
-  const handleToggleModal = () => {
-    setShowModal(!showModal);
-    handleShowProgressModal(false);
-  };
+
 
   return (
     <>
+    {!timeSeconds || timeSeconds === 0 ? (
+      <ProgressCardWithBarIndetermined
+        portalId="portal"
+      />
+    ) : (
       <ProgressCardWithBarDetermined
         estime={timeSeconds}
         progress={percentage}
         portalId="portal"
-        withButtonClose
         isAnimated={percentage === 100 ? false : true}
-        onCancel={handleToggleModal}
       />
-    </>
+    )}
+  </>
   );
 };
 

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -11,13 +11,6 @@ interface ProgressOfStartProcessOnDemandProps {
   handleShowProgressModal?: (showModal: boolean) => void;
 }
 
- //se crea funcion para que genere dos posibles tiempos aleatorios ya que se va ajustar 
-  //el endpoint que calcula el tiempo de inicio de un proceso
-  function getRandomTime(): string {
-    const randomValue = Math.floor(Math.random() * 2);
-    return randomValue === 0 ? "00:00:00" : "00:00:50";
-}
-
 const calculatePercentage = (
   currentMoment: number,
   time: number,
@@ -78,7 +71,7 @@ const ProgressOfStartProcessOnDemand = (
     };
   }, []);
 
-  const time = stringToTime(getRandomTime());
+  const time = stringToTime("00:00:50"); ///se coloca este tiempo para pruebas debido a que estan ajustando el endpoint que calcula el tiempo
   const timeSeconds = calculateSeconds(time);
 
   useEffect(() => {

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@inubekit/icon";
 import { Stack } from "@inubekit/stack";
 import { Spinner } from "@inubekit/spinner";
 import { Text } from "@inubekit/text";
+import { useFlag } from "@inubekit/flag";
 
 import { StartProcessModal } from "@components/modals/StartProcessModal";
 import { IEntries } from "@components/modals/MoreDetailsModal/types";
@@ -14,7 +15,6 @@ import { formatDate, formatDateEndpoint } from "@utils/dates";
 import { startProcess } from "@services/startProcess/patchStartProcess";
 import { IStartProcessResponse } from "@pages/startProcess/types";
 import { routesComponent } from "@pages/startProcess/config/routesForms.config";
-import { useFlag } from "@inubekit/flag";
 
 interface IStartProcessOnDemandProps {
   dataModal: IEntries;
@@ -67,16 +67,19 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
       
     } catch (error) {
       setError(true);
+  
       addFlag({
         title: "Error al iniciar los procesos",
         description:
           "No fue posible iniciar los procesos, por favor intenta más tarde",
         appearance: "danger",
         duration: 5000,
-      })
+      });
+      window.location.reload();
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
+      
     }
   };
 
@@ -171,7 +174,7 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
       {showProgressModal && (
         <Suspense fallback={null}>
           <ProgressOfStartProcessOnDemand
-            id={"9fa42ff7-4de8-4c50-b103-4399089652e0"} /// Se deja temporalmente este id ya que en proximas tareas se ajustara debido a que realizaran cambios en el endpoint que calcula el tiempo que se demora el iniciar un proceso
+            id={String(id) || ""}
             handleShowProgressModal={setShowProgressModal}
             dateStart={new Date()}
           />

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
@@ -94,19 +94,9 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
       if (responseStartProcess.processStatus === "Finished")
         navigate("/finished");
 
-      if (responseStartProcess.processStatus === "Initiated")
+      if (responseStartProcess.processStatus === "Initiated" || responseStartProcess.processStatus === "PartiallyStarted")
         navigate("/confirm-initiated");
 
-      if (responseStartProcess.processStatus === "PartiallyStarted")
-      {  setError(true);
-        addFlag({
-          title: "Error al iniciar los procesos",
-          description:
-            "No fue posible iniciar los procesos, por favor intenta más tarde",
-          appearance: "danger",
-          duration: 5000,
-        })
-      }
     }
   }, [responseStartProcess]);
 

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
@@ -14,6 +14,7 @@ import { formatDate, formatDateEndpoint } from "@utils/dates";
 import { startProcess } from "@services/startProcess/patchStartProcess";
 import { IStartProcessResponse } from "@pages/startProcess/types";
 import { routesComponent } from "@pages/startProcess/config/routesForms.config";
+import { useFlag } from "@inubekit/flag";
 
 interface IStartProcessOnDemandProps {
   dataModal: IEntries;
@@ -23,6 +24,7 @@ interface IStartProcessOnDemandProps {
 const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
   const { id, dataModal } = props;
   const [fieldsEntered, setFieldsEntered] = useState({} as IFieldsEntered);
+  const { addFlag } = useFlag();
 
   const navigate = useNavigate();
 
@@ -65,6 +67,13 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
       
     } catch (error) {
       setError(true);
+      addFlag({
+        title: "Error al iniciar los procesos",
+        description:
+          "No fue posible iniciar los procesos, por favor intenta más tarde",
+        appearance: "danger",
+        duration: 5000,
+      })
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
@@ -89,7 +98,15 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
         navigate("/confirm-initiated");
 
       if (responseStartProcess.processStatus === "PartiallyStarted")
-        setError(true);
+      {  setError(true);
+        addFlag({
+          title: "Error al iniciar los procesos",
+          description:
+            "No fue posible iniciar los procesos, por favor intenta más tarde",
+          appearance: "danger",
+          duration: 5000,
+        })
+      }
     }
   }, [responseStartProcess]);
 

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
@@ -39,7 +39,6 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
     useState<IStartProcessResponse>();
   const [showProgressModal, setShowProgressModal] = useState(false);
   const [showStartProcessModal, setShowStartProcessModal] = useState(false);
-  const [error, setError] = useState(false);
 
   const handleStartProcess = async () => {
     const processData = {
@@ -66,8 +65,7 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
       setResponseStartProcess(newProcess);
       
     } catch (error) {
-      setError(true);
-  
+      setShowProgressModal(false);
       addFlag({
         title: "Error al iniciar los procesos",
         description:
@@ -75,11 +73,9 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
         appearance: "danger",
         duration: 5000,
       });
-      window.location.reload();
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
-      
     }
   };
 
@@ -102,12 +98,6 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
 
     }
   }, [responseStartProcess]);
-
-  useEffect(() => {
-    if (error) {
-      setShowProgressModal(false);
-    }
-  }, [error]);
 
   const handleToggleModal = () => {
     setShowStartProcessModal(!showStartProcessModal);

--- a/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/onDemand/components/StartProcess/index.tsx
@@ -127,7 +127,7 @@ const StartProcessOnDemand = (props: IStartProcessOnDemandProps) => {
           )}
         </StartProcessModal>
       )}
-      {showProgressModal && (
+      {responseStartProcess?.processStatus === "Initiated" &&  showProgressModal && (
         <Suspense fallback={null}>
           <ProgressOfStartProcessOnDemand
             id={responseStartProcess?.processControlId || ""}

--- a/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
+++ b/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
@@ -55,7 +55,7 @@ const mapStartProcessOnDemand = (entry: StartProcesses) => {
   const formatDescriptionSuggested = 
       `${entry.description} Del mes de ${entry.month} del año ${entry.year}, fecha estimada de ejecución es ${entry.date}`;
   return {
-    id: entry.description,
+    id: entry.id,
     descriptionSuggested: formatDescriptionSuggested,
     publicCode: entry.publicCode,
     date: entry.dateWithoutFormat

--- a/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
+++ b/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
@@ -47,6 +47,7 @@ const mapOnDemand = (entry: StartProcesses) => {
     month: entry.month,
     year: entry.year,
     statusText: entry.statusText,
+    executionWay: entry.executionWay,
   };
 };
 
@@ -63,6 +64,7 @@ const mapStartProcessOnDemand = (entry: StartProcesses) => {
     month: entry.month,
     year: entry.year,
     url: entry.url,
+    executionWay: entry.executionWay,
   };
 };
 

--- a/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
+++ b/src/pages/startProcess/tabs/onDemand/config/card.config.tsx
@@ -13,7 +13,7 @@ const onDemandNormailzeEntries = (
 ) =>
   process.map((entry) => ({
     ...entry,
-    id: `${entry.id}${entry.date}`,
+    id: `${entry.id}`,
     publicCode: entry.publicCode,
     process: entry.description,
     date: formatDate(new Date()),

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -2,12 +2,21 @@ import { useEffect, useState } from "react";
 
 import { ProgressCardWithBarDetermined } from "@components/feedback/ProgressCardWithBarDetermined";
 import { timeToCompleteProcess } from "@services/startProcess/getTimeToCompleteProcess";
+import { ProgressCardWithBarIndetermined } from "@components/feedback/ProgressCardWithBarIndetermined";
 import { calculateSeconds, stringToTime } from "@pages/startProcess/utils";
 
 interface ProgressOfStartProcessProps {
   id: string;
   handleShowProgressModal: (showModal: boolean) => void;
   dateStart: Date;
+}
+
+
+  //se crea funcion para que genere dos posibles tiempos aleatorios ya que se va ajustar 
+  //el endpoint que calcula el tiempo de inicio de un proceso
+  function getRandomTime(): string {
+    const randomValue = Math.floor(Math.random() * 2);
+    return randomValue === 0 ? "00:00:00" : "00:00:50";
 }
 
 const calculatePercentage = (
@@ -33,23 +42,24 @@ const percentageElapsed = (
   const currentMoment = calculateSeconds(dateCurrent);
   const percentageResp = calculatePercentage(currentMoment, time, dateStart);
 
-  if (percentageResp >= 100 || isNaN(percentageResp)) {
+  if (percentageResp >= 100) {
     return 100;
   }
   return percentageResp;
 };
 
 const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
-  const { id, handleShowProgressModal, dateStart } = props;
+  const { id, dateStart} =
+    props;
   const [percentage, setPercentage] = useState(0);
-  const [showModal, setShowModal] = useState(false);
   const [processTime, setProcessTime] = useState<string>("");
 
   const validateTimeToCompleteProcess = async (progressControlId: string) => {
     try {
       const newTime = await timeToCompleteProcess(progressControlId);
       setProcessTime(newTime.duration);
-      setShowModal(true);
+
+      processTime
     } catch (error) {
       console.info(error);
     }
@@ -69,7 +79,7 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
     };
   }, []);
 
-  const time = stringToTime(processTime);
+  const time = stringToTime(getRandomTime());
   const timeSeconds = calculateSeconds(time);
 
   useEffect(() => {
@@ -90,21 +100,22 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
     return () => clearInterval(timer);
   }, [percentage]);
 
-  const handleToggleModal = () => {
-    setShowModal(!showModal);
-    handleShowProgressModal(false);
-  };
-
+  
   return (
     <>
-      <ProgressCardWithBarDetermined
-        estime={timeSeconds}
-        progress={percentage}
-        portalId="portal"
-        withButtonClose
-        isAnimated={percentage === 100 ? false : true}
-        onCancel={handleToggleModal}
-      />
+      {!timeSeconds || timeSeconds === 0 ? (
+        <ProgressCardWithBarIndetermined
+          portalId="portal"
+
+        />
+      ) : (
+        <ProgressCardWithBarDetermined
+          estime={timeSeconds}
+          progress={percentage}
+          portalId="portal"
+          isAnimated={percentage === 100 ? false : true}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -11,14 +11,6 @@ interface ProgressOfStartProcessProps {
   dateStart: Date;
 }
 
-
-  //se crea funcion para que genere dos posibles tiempos aleatorios ya que se va ajustar 
-  //el endpoint que calcula el tiempo de inicio de un proceso
-  function getRandomTime(): string {
-    const randomValue = Math.floor(Math.random() * 2);
-    return randomValue === 0 ? "00:00:00" : "00:00:50";
-}
-
 const calculatePercentage = (
   currentMoment: number,
   time: number,
@@ -58,7 +50,6 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
     try {
       const newTime = await timeToCompleteProcess(progressControlId);
       setProcessTime(newTime.duration);
-
       processTime
     } catch (error) {
       console.info(error);
@@ -79,7 +70,7 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
     };
   }, []);
 
-  const time = stringToTime(getRandomTime());
+  const time = stringToTime("00:00:00"); ///se coloca este tiempo para pruebas debido a que estan ajustando el endpoint que calcula el tiempo
   const timeSeconds = calculateSeconds(time);
 
   useEffect(() => {

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -41,20 +41,20 @@ const percentageElapsed = (
 };
 
 const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
-  const { id, dateStart} =
-    props;
+  const { id, dateStart } = props;
   const [percentage, setPercentage] = useState(0);
-  const [processTime, setProcessTime] = useState<string>("");
+  const [processTime, setProcessTime] = useState<number | undefined>();
+  const [time, setTime] = useState<Date | undefined>();
 
   const validateTimeToCompleteProcess = async (progressControlId: string) => {
     try {
       const newTime = await timeToCompleteProcess(progressControlId);
-      setProcessTime(newTime.duration);
-      processTime
+      setProcessTime(newTime.secondsTime);
     } catch (error) {
       console.info(error);
     }
   };
+
   useEffect(() => {
     validateTimeToCompleteProcess(id);
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -68,10 +68,15 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, []);
+  }, [id]);
 
-  const time = stringToTime("00:00:00"); ///se coloca este tiempo para pruebas debido a que estan ajustando el endpoint que calcula el tiempo
-  const timeSeconds = calculateSeconds(time);
+  useEffect(() => {
+    if (processTime) {
+      setTime(stringToTime(processTime));
+    }
+  }, [processTime]);
+
+  const timeSeconds = time ? calculateSeconds(time as Date) : 0;
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -89,16 +94,12 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
       }
     }, 300);
     return () => clearInterval(timer);
-  }, [percentage]);
+  }, [percentage, timeSeconds, dateStart]);
 
-  
   return (
     <>
-      {!timeSeconds || timeSeconds === 0 ? (
-        <ProgressCardWithBarIndetermined
-          portalId="portal"
-
-        />
+      {!time ? (
+        <ProgressCardWithBarIndetermined portalId="portal" />
       ) : (
         <ProgressCardWithBarDetermined
           estime={timeSeconds}

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -46,9 +46,9 @@ const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
   const [processTime, setProcessTime] = useState<number | undefined>();
   const [time, setTime] = useState<Date | undefined>();
 
-  const validateTimeToCompleteProcess = async (progressControlId: string) => {
+  const validateTimeToCompleteProcess = async (progressCatalogId: string) => {
     try {
-      const newTime = await timeToCompleteProcess(progressControlId);
+      const newTime = await timeToCompleteProcess(progressCatalogId);
       setProcessTime(newTime.secondsTime);
     } catch (error) {
       console.info(error);

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/ProgressOfStartProcess/index.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+
+import { ProgressCardWithBarDetermined } from "@components/feedback/ProgressCardWithBarDetermined";
+import { timeToCompleteProcess } from "@services/startProcess/getTimeToCompleteProcess";
+import { calculateSeconds, stringToTime } from "@pages/startProcess/utils";
+
+interface ProgressOfStartProcessProps {
+  id: string;
+  handleShowProgressModal: (showModal: boolean) => void;
+  dateStart: Date;
+}
+
+const calculatePercentage = (
+  currentMoment: number,
+  time: number,
+  dateStart: Date
+) => {
+  const secondsElapsed = currentMoment - calculateSeconds(dateStart);
+  const secondsValid = secondsElapsed >= 0 ? secondsElapsed : 0;
+  return (secondsValid / time) * 100;
+};
+
+const percentageElapsed = (
+  time: number,
+  percentageDos: number,
+  dateStart: Date
+): number => {
+  if (percentageDos >= 100) {
+    return percentageDos;
+  }
+
+  const dateCurrent = new Date();
+  const currentMoment = calculateSeconds(dateCurrent);
+  const percentageResp = calculatePercentage(currentMoment, time, dateStart);
+
+  if (percentageResp >= 100 || isNaN(percentageResp)) {
+    return 100;
+  }
+  return percentageResp;
+};
+
+const ProgressOfStartProcess = (props: ProgressOfStartProcessProps) => {
+  const { id, handleShowProgressModal, dateStart } = props;
+  const [percentage, setPercentage] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [processTime, setProcessTime] = useState<string>("");
+
+  const validateTimeToCompleteProcess = async (progressControlId: string) => {
+    try {
+      const newTime = await timeToCompleteProcess(progressControlId);
+      setProcessTime(newTime.duration);
+      setShowModal(true);
+    } catch (error) {
+      console.info(error);
+    }
+  };
+  useEffect(() => {
+    validateTimeToCompleteProcess(id);
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const message = "¿Estás seguro de que quieres salir?";
+      event.returnValue = message;
+      return message;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  const time = stringToTime(processTime);
+  const timeSeconds = calculateSeconds(time);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const newPercentage = percentageElapsed(
+        timeSeconds,
+        percentage,
+        dateStart
+      );
+
+      if (newPercentage >= 100) {
+        clearInterval(timer);
+        setPercentage(100);
+      } else {
+        setPercentage(newPercentage);
+      }
+    }, 300);
+    return () => clearInterval(timer);
+  }, [percentage]);
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+    handleShowProgressModal(false);
+  };
+
+  return (
+    <>
+      <ProgressCardWithBarDetermined
+        estime={timeSeconds}
+        progress={percentage}
+        portalId="portal"
+        withButtonClose
+        isAnimated={percentage === 100 ? false : true}
+        onCancel={handleToggleModal}
+      />
+    </>
+  );
+};
+
+export default ProgressOfStartProcess;

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@inubekit/icon";
 import { Stack } from "@inubekit/stack";
 import { Spinner } from "@inubekit/spinner";
 import { Text } from "@inubekit/text";
+import { useFlag } from "@inubekit/flag";
 
 import { StartProcessModal } from "@components/modals/StartProcessModal";
 import { IEntries } from "@components/modals/MoreDetailsModal/types";
@@ -14,7 +15,6 @@ import { formatDate, formatDateEndpoint } from "@utils/dates";
 import { IStartProcessResponse } from "@pages/startProcess/types";
 import { startProcess } from "@services/startProcess/patchStartProcess";
 import { routesComponent } from "@pages/startProcess/config/routesForms.config";
-import { useFlag } from "@inubekit/flag";
 
 interface IStartProcessScheduledProps {
   id: string;
@@ -75,7 +75,7 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
         appearance: "danger",
         duration: 5000,
       })
-
+      window.location.reload();
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
@@ -173,7 +173,7 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
       {showProgressModal && (
         <Suspense fallback={null}>
           <ProgressOfStartProcess
-            id={"9fa42ff7-4de8-4c50-b103-4399089652e0"} /// Se deja temporalmente este id ya que en proximas tareas se ajustara debido a que realizaran cambios en el endpoint que calcula el tiempo que se demora el iniciar un proceso
+            id={String(id) || ""}
             handleShowProgressModal={setShowProgressModal}
             dateStart={new Date()}
           />

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
@@ -95,19 +95,9 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
       if (responseStartProcess.processStatus === "Finished")
         navigate("/finished");
 
-      if (responseStartProcess.processStatus === "Initiated")
+      if (responseStartProcess.processStatus === "Initiated" || responseStartProcess.processStatus === "PartiallyStarted")
         navigate("/confirm-initiated");
 
-      if (responseStartProcess.processStatus === "PartiallyStarted"){
-        setError(true);
-        addFlag({
-          title: "Error al iniciar los procesos",
-          description:
-            "No fue posible iniciar los procesos, por favor intenta más tarde",
-          appearance: "danger",
-          duration: 5000,
-        })
-      }
     }
   }, [responseStartProcess]);
 

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
@@ -128,7 +128,7 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
         </StartProcessModal>
       )}
       {
-        showProgressModal && (
+        responseStartProcess?.processStatus === "Initiated" && showProgressModal && (
           <Suspense fallback={null}>
             <ProgressOfStartProcess
               id={responseStartProcess?.processControlId || ""}

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
@@ -40,7 +40,6 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
     useState<IStartProcessResponse>();
   const [showStartProcessModal, setShowStartProcessModal] = useState(false);
   const [showProgressModal, setShowProgressModal] = useState(false);
-  const [error, setError] = useState(false);
 
   const {addFlag} =useFlag();
 
@@ -67,7 +66,7 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
       const newProcess = await startProcess(processData);
       setResponseStartProcess(newProcess);
     } catch (error) {
-      setError(true);
+      setShowProgressModal(false)
       addFlag({
         title: "Error al iniciar los procesos",
         description:
@@ -75,7 +74,6 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
         appearance: "danger",
         duration: 5000,
       })
-      window.location.reload();
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
@@ -100,12 +98,6 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
 
     }
   }, [responseStartProcess]);
-
-  useEffect(() => {
-    if (error) {
-      setShowProgressModal(false);
-    }
-  }, [error]);
 
   const handleToggleModal = () => {
     setShowStartProcessModal(!showStartProcessModal);

--- a/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
+++ b/src/pages/startProcess/tabs/scheduled/components/StartProcess/index.tsx
@@ -14,6 +14,7 @@ import { formatDate, formatDateEndpoint } from "@utils/dates";
 import { IStartProcessResponse } from "@pages/startProcess/types";
 import { startProcess } from "@services/startProcess/patchStartProcess";
 import { routesComponent } from "@pages/startProcess/config/routesForms.config";
+import { useFlag } from "@inubekit/flag";
 
 interface IStartProcessScheduledProps {
   id: string;
@@ -41,6 +42,8 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
   const [showProgressModal, setShowProgressModal] = useState(false);
   const [error, setError] = useState(false);
 
+  const {addFlag} =useFlag();
+
   const handleStartProcess = async () => {
     const processData = {
       processCatalogId: String(id),
@@ -65,6 +68,14 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
       setResponseStartProcess(newProcess);
     } catch (error) {
       setError(true);
+      addFlag({
+        title: "Error al iniciar los procesos",
+        description:
+          "No fue posible iniciar los procesos, por favor intenta más tarde",
+        appearance: "danger",
+        duration: 5000,
+      })
+
       throw new Error(
         `Error al iniciar los procesos en formulario: ${(error as Error).message} `
       );
@@ -87,8 +98,16 @@ const StartProcessScheduled = (props: IStartProcessScheduledProps) => {
       if (responseStartProcess.processStatus === "Initiated")
         navigate("/confirm-initiated");
 
-      if (responseStartProcess.processStatus === "PartiallyStarted")
+      if (responseStartProcess.processStatus === "PartiallyStarted"){
         setError(true);
+        addFlag({
+          title: "Error al iniciar los procesos",
+          description:
+            "No fue posible iniciar los procesos, por favor intenta más tarde",
+          appearance: "danger",
+          duration: 5000,
+        })
+      }
     }
   }, [responseStartProcess]);
 

--- a/src/pages/startProcess/tabs/scheduled/config/card.config.tsx
+++ b/src/pages/startProcess/tabs/scheduled/config/card.config.tsx
@@ -58,7 +58,7 @@ const mapStartProcessScheduled = (entry: StartProcesses) => {
   const formatDescriptionSuggested = 
     `${entry.description} Del mes de ${entry.month} del año ${entry.year}, fecha estimada de ejecución es ${entry.date}`;
   return {
-    id: entry.description,
+    id: entry.id,
     descriptionSuggested: formatDescriptionSuggested,
     publicCode: entry.publicCode,
     date: entry.dateWithoutFormat,

--- a/src/pages/startProcess/tabs/scheduled/config/card.config.tsx
+++ b/src/pages/startProcess/tabs/scheduled/config/card.config.tsx
@@ -35,6 +35,7 @@ const scheduledNormailzeEntries = (
     month: month,
     year: year,
     dateWithoutFormat: entry.date,
+    executionWay: entry.executionWay,
   }));
 
 const mapScheduled = (entry: StartProcesses) => {
@@ -64,6 +65,7 @@ const mapStartProcessScheduled = (entry: StartProcesses) => {
     month: entry.month,
     year: entry.year,
     url: entry.url,
+    executionWay: entry.executionWay
   };
 };
 

--- a/src/pages/startProcess/types.ts
+++ b/src/pages/startProcess/types.ts
@@ -119,9 +119,7 @@ interface IListPeriods {
 }
 
 interface ITimeEstimedCompleteProcess {
-  totalPersons: number;
-  totalProcessedPersons: number;
-  duration: string;
+  secondsTime: number;
 }
 
 export type appearances = (typeof appearance)[number];

--- a/src/pages/startProcess/types.ts
+++ b/src/pages/startProcess/types.ts
@@ -32,7 +32,7 @@ interface StartProcesses {
   actions?: IActions[];
   month?: number;
   year?: number;
-  plannedAutomaticExecution?: string;
+  executionWay?: string;
   dateWithoutFormat?: string;
   url?: string;
 }

--- a/src/pages/startProcess/types.ts
+++ b/src/pages/startProcess/types.ts
@@ -113,6 +113,12 @@ interface IData {
   actionsRequirements?: IAction[];
 }
 
+interface ITimeEstimedCompleteProcess {
+  totalPersons: number;
+  totalProcessedPersons: number;
+  duration: string;
+}
+
 export type appearances = (typeof appearance)[number];
 
 export type {
@@ -126,4 +132,5 @@ export type {
   ITitlesRequirements,
   IData,
   IDailyDetail,
+  ITimeEstimedCompleteProcess
 };

--- a/src/pages/startProcess/utils.tsx
+++ b/src/pages/startProcess/utils.tsx
@@ -1,21 +1,20 @@
 import { Button } from "@inubekit/button";
 
 import { StyledContainerButton } from "./styles";
-import { Tag } from "@inubekit/tag";
 
+const stringToTime = (timeString: string): Date => {
+  const [hours, minutes, seconds] = timeString.split(":").map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes, seconds, 0);
+  return date;
+};
 
-const formatStatus = (status: string) => {
-  if (status === "No cumple" ) {
-    return <Tag label="Error" appearance="danger" weight="strong" />;
-  }
-
-  if (status === "Cumple") {
-    return <Tag label="Sin Procesar" appearance="success" weight="strong" />;
-  }
-
-  if (status === "Sin evaluar") {
-    return <Tag label="Sin Procesar" appearance="warning" weight="strong" />;
-  }
+const calculateSeconds = (dateProcess: Date) => {
+  return (
+    dateProcess.getHours() * 3600 +
+    dateProcess.getMinutes() * 60 +
+    dateProcess.getSeconds()
+  );
 };
 
 const requirementsData = () => {
@@ -56,4 +55,9 @@ const requirementsButton = () => {
   );
 };
 
-export { requirementsData, requirementsButton, formatStatus };
+export {
+  stringToTime,
+  calculateSeconds,
+  requirementsData,
+  requirementsButton,
+};

--- a/src/pages/startProcess/utils.tsx
+++ b/src/pages/startProcess/utils.tsx
@@ -2,8 +2,11 @@ import { Button } from "@inubekit/button";
 
 import { StyledContainerButton } from "./styles";
 
-const stringToTime = (timeString: string): Date => {
-  const [hours, minutes, seconds] = timeString.split(":").map(Number);
+const stringToTime = (secondsProcess: number): Date => {
+  
+  const hours = Math.floor(secondsProcess / 3600);
+  const minutes = Math.floor((secondsProcess % 3600) / 60);
+  const seconds = secondsProcess % 60;
   const date = new Date();
   date.setHours(hours, minutes, seconds, 0);
   return date;

--- a/src/services/startProcess/getStartProcess/mappers.ts
+++ b/src/services/startProcess/getStartProcess/mappers.ts
@@ -14,6 +14,7 @@ const mapStartProcessApiToEntity = (
     dateWithoutFormat: String(process.estimatedExecutionDate),
     url: String(process.urlExecutionParameters),
     dailyDetail: Object(process.dailyDetail),
+    executionWay: String(process.executionWay),
   };
   return processes;
 };

--- a/src/services/startProcess/getTimeToCompleteProcess/index.ts
+++ b/src/services/startProcess/getTimeToCompleteProcess/index.ts
@@ -7,15 +7,13 @@ import { ITimeEstimedCompleteProcess } from "@pages/startProcess/types";
 import { mapTimeToCompleteProcessApiToEntity } from "./mappers";
 
 const timeToCompleteProcess = async (
-  processControlId: string
+  processCatalogId: string
 ): Promise<ITimeEstimedCompleteProcess> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
 
   const emptyResponse = {
-    totalPersons: 0,
-    totalProcessedPersons: 0,
-    duration: "",
+    secondsTime: 0,
   };
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -26,7 +24,7 @@ const timeToCompleteProcess = async (
       const options: RequestInit = {
         method: "GET",
         headers: {
-          "X-Action": "CalculateEstimatedTimeToCompleteProcess",
+          "X-Action": "SearchEstimatedTimeToInsertPeople",
           "X-Business-Unit": enviroment.TEMP_BUSINESS_UNIT,
           "Content-type": "application/json; charset=UTF-8",
         },
@@ -34,7 +32,7 @@ const timeToCompleteProcess = async (
       };
 
       const res = await fetch(
-        `${enviroment.IPROCESS_API_URL_QUERY}/process-controls/process-control-executions/${processControlId}`,
+        `${enviroment.IPROCESS_API_URL_QUERY}/process-controls/information/${processCatalogId}`,
         options
       );
 
@@ -48,7 +46,7 @@ const timeToCompleteProcess = async (
 
       if (!res.ok) {
         throw {
-          message: `Error al obtener el tiempo estimado al iniciar el proceso ${processControlId}`,
+          message: `Error al obtener el tiempo estimado al iniciar el proceso ${processCatalogId}`,
           status: res.status,
           data,
         };

--- a/src/services/startProcess/getTimeToCompleteProcess/index.ts
+++ b/src/services/startProcess/getTimeToCompleteProcess/index.ts
@@ -1,0 +1,72 @@
+import {
+  enviroment,
+  fetchTimeoutServices,
+  maxRetriesServices,
+} from "@config/environment";
+import { ITimeEstimedCompleteProcess } from "@pages/startProcess/types";
+import { mapTimeToCompleteProcessApiToEntity } from "./mappers";
+
+const timeToCompleteProcess = async (
+  processControlId: string
+): Promise<ITimeEstimedCompleteProcess> => {
+  const maxRetries = maxRetriesServices;
+  const fetchTimeout = fetchTimeoutServices;
+
+  const emptyResponse = {
+    totalPersons: 0,
+    totalProcessedPersons: 0,
+    duration: "",
+  };
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), fetchTimeout);
+
+      const options: RequestInit = {
+        method: "GET",
+        headers: {
+          "X-Action": "CalculateEstimatedTimeToCompleteProcess",
+          "X-Business-Unit": enviroment.TEMP_BUSINESS_UNIT,
+          "Content-type": "application/json; charset=UTF-8",
+        },
+        signal: controller.signal,
+      };
+
+      const res = await fetch(
+        `${enviroment.IPROCESS_API_URL_QUERY}/process-controls/process-control-executions/${processControlId}`,
+        options
+      );
+
+      clearTimeout(timeoutId);
+
+      if (res.status === 204) {
+        return emptyResponse;
+      }
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw {
+          message: "Error al obtener los procesos",
+          status: res.status,
+          data,
+        };
+      }
+
+      const normalizedStartProcess = mapTimeToCompleteProcessApiToEntity(data);
+
+      return normalizedStartProcess;
+    } catch (error) {
+      if (attempt === maxRetries) {
+        throw new Error(
+          "Todos los intentos fallaron. No fue posible obtener el tiempo estimado."
+        );
+      }
+    }
+  }
+
+  return emptyResponse;
+};
+
+export { timeToCompleteProcess };

--- a/src/services/startProcess/getTimeToCompleteProcess/index.ts
+++ b/src/services/startProcess/getTimeToCompleteProcess/index.ts
@@ -48,15 +48,15 @@ const timeToCompleteProcess = async (
 
       if (!res.ok) {
         throw {
-          message: "Error al obtener los procesos",
+          message: `Error al obtener el tiempo estimado al iniciar el proceso ${processControlId}`,
           status: res.status,
           data,
         };
       }
 
-      const normalizedStartProcess = mapTimeToCompleteProcessApiToEntity(data);
+      const normalizedTimeToCompleteProcess = mapTimeToCompleteProcessApiToEntity(data);
 
-      return normalizedStartProcess;
+      return normalizedTimeToCompleteProcess;
     } catch (error) {
       if (attempt === maxRetries) {
         throw new Error(

--- a/src/services/startProcess/getTimeToCompleteProcess/mappers.ts
+++ b/src/services/startProcess/getTimeToCompleteProcess/mappers.ts
@@ -1,0 +1,16 @@
+import { ITimeEstimedCompleteProcess} from "@pages/startProcess/types";
+
+const mapTimeToCompleteProcessApiToEntity = (
+  data:  Record<string, string | number | object> 
+): ITimeEstimedCompleteProcess => {
+  const processes: ITimeEstimedCompleteProcess = {
+    totalPersons: Number(data.totalPersons),
+    totalProcessedPersons: Number(data.totalProcessedPersons),
+    duration: String(data.remainingDuration),
+  };
+  return processes;
+};
+
+
+
+export { mapTimeToCompleteProcessApiToEntity };

--- a/src/services/startProcess/getTimeToCompleteProcess/mappers.ts
+++ b/src/services/startProcess/getTimeToCompleteProcess/mappers.ts
@@ -4,9 +4,7 @@ const mapTimeToCompleteProcessApiToEntity = (
   data:  Record<string, string | number | object> 
 ): ITimeEstimedCompleteProcess => {
   const processes: ITimeEstimedCompleteProcess = {
-    totalPersons: Number(data.totalPersons),
-    totalProcessedPersons: Number(data.totalProcessedPersons),
-    duration: String(data.remainingDuration),
+    secondsTime: Number(data.secondsTimeToInsertPeople),
   };
   return processes;
 };

--- a/src/services/startProcess/patchStartProcess/index.tsx
+++ b/src/services/startProcess/patchStartProcess/index.tsx
@@ -27,7 +27,7 @@ const startProcess = async (process: IStartProcessesRequest): Promise<
 
     if (!res.ok) {
       throw {
-        message: "Error al descartar publicación",
+        message: "Error al iniciar proceso",
         status: res.status,
         data,
       };


### PR DESCRIPTION
Add progress modal to start process and redirect start processes  from the jira card prcss75

Since when starting any process in the "inicio proceso" modal the response of the service consumed from the estimated time is "00:00:00" ,then 10 seconds are placed as a test to see the operation of the progress bar

**### _Video of operation attached:_**

https://github.com/user-attachments/assets/e8c915c6-e381-4f02-b18d-e8d86f45f160

